### PR TITLE
Upgrade Lambda NodeJS version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -1,7 +1,7 @@
 service: edge-rewrite
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs10.x
   stage: ${opt:stage, self:custom.defaultStage}
   profile: ${self:custom.profiles.${self:provider.stage}}
 


### PR DESCRIPTION
NodeJS 6.10 is no longer available for deployments on AWS Lambda, so upgrade to the current latest.
